### PR TITLE
fix deprecated set-env call

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -1,5 +1,7 @@
 on:
   push:
+    branches:
+      - workflow-debug
     tags:
     - '*'
 
@@ -10,11 +12,11 @@ jobs:
       - uses: actions/checkout@v2
       - name: Get the version
         id: get_version
-        run: echo ::set-env name=VERSION::${GITHUB_REF#refs/tags/}
+        run: echo "::set-output name=version::${GITHUB_REF#refs/tags/}\n"
       - uses: docker/build-push-action@v1.1.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
           repository: luckyframeworkdocker/lucky-crystal
-          tags: cache, ${{ env.VERSION }}
+          tags: cache, ${{ steps.get_version.outputs.version }}
           cache_froms: luckyframeworkdocker/lucky-crystal:cache


### PR DESCRIPTION
Fixes (hopefully) CI error:
```
Error: Unable to process command '::set-env name=VERSION::l0.25.0c0.35.1-alpine' successfully.
Error: The `set-env` command is disabled. Please upgrade to using Environment Files or opt into unsecure command execution by setting the 
```