### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN git clone https://github.com/luckyframework/lucky_cli && \
 WORKDIR /usr/local/lucky_cli
 RUN crystal build src/lucky.cr -o /usr/local/bin/lucky
 
-FROM crystallang/crystal:0.35.1-alpine as runtime-image
+FROM crystallang/crystal:0.36.1-alpine as runtime-image
 
 RUN apk add --no-cache --update postgresql-client
 COPY --from=build-image /usr/local/bin/lucky /usr/local/bin/lucky


### PR DESCRIPTION
Final image was still using crystal:0.35.1, causing shard install errors on dockerfiles that build from this image.